### PR TITLE
Add Elements examples to prototype

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,8 @@ module.exports = function(grunt){
       dev: {
         files: {
           'public/stylesheets/application.css': 'public/sass/application.scss',
-          'public/stylesheets/examples.css': 'public/sass/examples.scss'
+          'public/stylesheets/examples.css': 'public/sass/examples.scss',
+          'public/stylesheets/elements.css': 'public/sass/elements.scss'
         },
         options: {
           includePaths: ['govuk/public/sass'],

--- a/public/sass/elements.scss
+++ b/public/sass/elements.scss
@@ -1,0 +1,49 @@
+/* includes node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit/stylesheets */
+
+// Import GOV.UK frontend toolkit
+
+@import "_colours";
+@import "_css3";
+@import "_shims";
+@import "_typography";
+@import "_measurements";
+
+@import "design-patterns/_alpha-beta";
+@import "design-patterns/_buttons";
+
+
+// Import GOV.UK elements styles - basic styles for typography and layout
+
+// Helper classes
+@import "elements/_helpers.scss";
+
+// Main content wrapper
+@import "elements/_main-wrapper.scss";
+
+// Scope the elements to .govuk
+// We only want to apply these styles to the main content wrapper, apply the govuk class here
+
+.govuk {
+
+  // Typography
+  @import "elements/_typography-base.scss";
+  @import "elements/_typography-general.scss";
+  @import "elements/_typography-headings.scss";
+  @import "elements/_typography-data.scss";
+  
+  // Grids
+  @import "elements/_grid-wrapper.scss";
+  @import "elements/_grid-unit.scss";
+  @import "elements/_grid-1-2.scss";
+  @import "elements/_grid-1-3.scss";
+  @import "elements/_grid-1-4.scss";
+  @import "elements/_grid-2-3.scss";
+  @import "elements/_grid-3-4.scss";
+
+  // Modules
+  @import "elements/_buttons.scss";
+  @import "elements/_colours.scss";
+  @import "elements/_lists.scss";
+  @import "elements/_forms.scss";
+
+}

--- a/public/sass/elements/_buttons.scss
+++ b/public/sass/elements/_buttons.scss
@@ -1,0 +1,56 @@
+.button {
+	@include button ($green);
+	margin: 0 $gutter-half $gutter-half 0;
+	padding: 10px 10px 5px 10px;
+	vertical-align: top;
+}
+.button:focus {
+	outline: 3px solid $yellow;
+}
+
+// Start now buttons
+.get-started .button {
+	@include bold-24;
+	line-height: 0.66667;
+	background-color: #00823b; // Not in palette!! 
+	padding: 0.60em 1.7em 0.45em 0.67em;
+	background-image: url(https://assets.digital.cabinet-office.gov.uk/static/icon-pointer-063838cde108768e30b077e5303783fc.png);
+	background-position: 100% 50%;
+	background-repeat: no-repeat;
+	margin-bottom: 0;
+}
+.get-started .button:hover {
+	background-color: $green;
+}
+
+.get-started .destination {
+	@include core-14;
+	color: #2e3133;
+	display: block;
+	margin-top: 7px;
+	max-width: 182px;
+}
+
+// Link style buttons
+.button-link {
+	// Remove browser default button styles
+	background: none;
+	border: none;
+	// Override webkit default button styles
+	-webkit-font-smoothing: antialiased;
+	// Match .button styles
+	display: inline-block;
+	color: $link-colour;
+	line-height: 1.25;
+	text-decoration: underline;
+	cursor: pointer;
+	margin: 0 $gutter-half $gutter-half 0;
+	padding: 10px 10px 5px 10px;
+	vertical-align: top;
+}
+.button-link:hover {
+	color: $link-hover-colour;
+}
+.button-link:focus {
+	outline: 3px solid $yellow;
+}

--- a/public/sass/elements/_colours.scss
+++ b/public/sass/elements/_colours.scss
@@ -1,0 +1,47 @@
+// Sass list for colour palette
+
+$palette: ( 
+  ("purple", $purple, $purple-50, $purple-25), 
+  ("mauve", $mauve, $mauve-50, $mauve-25),
+  ("fuschia", $fuschia, $fuschia-50, $fuschia-25),
+  ("pink", $pink, $pink-50, $pink-25),
+  ("baby-pink", $baby-pink, $baby-pink-50, $baby-pink-25),
+  ("red", $red, $red-50, $red-25),
+  ("mellow-red", $mellow-red, $mellow-red-50, $mellow-red-25),
+  ("orange", $orange,$orange-50,$orange-25),
+  ("brown", $brown,$brown-50,$brown-25),
+  ("yellow", $yellow,$yellow-50,$yellow-25),
+  ("green", $green,$green-50,$green-25),
+  ("grass-green", $grass-green,$grass-green-50,$grass-green-25),
+  ("turquoise", $turquoise,$turquoise-50,$turquoise-25),
+  ("light-blue", $light-blue,$light-blue-50,$light-blue-25)
+ );
+
+// Generate class colours from colour palette
+
+@each $color in $palette {
+
+  $color-name: nth($color, 1);
+  $color-var: nth($color, 2);
+  $color-var-50: nth($color, 3);
+  $color-var-25: nth($color, 4);
+
+  .colour-#{$color-name} {
+    background-color: $color-var;
+  }
+  .colour-#{$color-name}-50 {
+    background-color: $color-var-50;
+  }
+  .colour-#{$color-name}-25 {
+    background-color: $color-var-25;
+  }
+  
+}
+
+.text-secondary {
+  color: $secondary-text-colour;
+}
+
+.bg-hm-government {
+  background: $hm-government;
+}

--- a/public/sass/elements/_forms.scss
+++ b/public/sass/elements/_forms.scss
@@ -1,0 +1,253 @@
+// Normalize form elements
+
+form {
+  margin: 0;
+}
+
+fieldset {
+  width: 100%;
+  float: left;
+  clear: both;
+  margin-left: 0;
+}
+
+legend {
+  padding-left: 0;
+  width: 100%;
+  float: left;
+  clear: both;
+}
+
+// Swap legend margins for padding
+legend.heading-36 {
+  margin: 0;
+  padding-top: 45px;
+  padding-bottom: ($gutter*1.5);
+}
+
+legend.heading-24 {
+  margin: 0;
+  padding-top: 45px;
+  padding-bottom: 20px
+}
+
+
+button,
+input,
+select,
+textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+button,
+input {
+    line-height: normal;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="date"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="email"],
+input[type="month"],
+input[type="number"],
+input[type="search"],
+input[type="tel"],
+input[type="time"],
+input[type="url"],
+input[type="week"],
+select[size],
+textarea {
+  font-size: 1em;
+  
+  padding: 4px;
+  background-color: $white;
+  border: 1px solid $border-colour;
+  
+  // Disable webkit appearance and remove rounded corners
+  -webkit-appearance: none;
+  border-radius: 0;
+}
+
+textarea {
+  overflow: auto;
+  vertical-align: top;
+  min-height: 190px;
+  height: auto;
+}
+
+// Form group is used to wrap label and input pairs
+
+.form-group {
+  float: left;
+  width: 100%;
+  clear: both;
+  @extend .cf;
+  @include media(tablet) {
+    margin-bottom: ($gutter*1.5);
+  }
+}
+
+.form-group-compound {
+  margin-bottom: 10px;
+}
+
+
+// Form labels, or for legends styled to look like labels
+.form-label,
+.form-group label {
+  @include core-19;
+  display: block;
+  margin-bottom: 5px;
+}
+
+
+// By default, form controls are 50% width for desktop and 100% width for mobile
+
+.form-control {
+  width: 100%;
+  box-sizing: border-box;
+  @include media(tablet) {
+    width: 50%;
+  }
+}
+
+// Form control widths
+
+.form-control-3-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 75%;
+  }
+}
+
+.form-control-1-2 {
+  width: 100%;
+  @include media(tablet) {
+    width: 50%;
+  }
+}
+
+.form-control-1-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 25%;
+  }
+}
+
+.form-control-1-8 {
+  width: 100%;
+  @include media(tablet) {
+    width: 12.5%;
+  }
+}
+
+// Form hints & examples are light grey and sit above a form control
+
+.form-hint {
+  display: block;
+  color: $secondary-text-colour;
+  margin-top: 8px;
+  margin-bottom: 5px;
+}
+
+
+// Date of birth
+
+.date-of-birth legend {
+  @extend .form-label;
+}
+.date-of-birth label {
+  display: block;
+  color: $grey-1;
+  margin-bottom: 5px;
+}
+.date-of-birth .form-group {  
+  @include media(tablet){
+    width: 50px;
+    float: left;
+    margin-right: 20px;
+    clear: none;
+  }
+}
+.date-of-birth .form-group-year {
+  @include media(tablet){
+    width: 70px;
+  }
+}
+.date-of-birth .form-group input {
+  width: 100%;
+}
+
+// Vertical alignment of checkboxes
+
+.form-checkbox input {
+  vertical-align: middle;
+  margin: -2px 5px 0 0;
+}
+
+// Vertical alignment of radio buttons
+
+.form-radio input {
+  vertical-align: middle;
+  margin: -4px 5px 0 0;
+}
+
+// Grey indented panels
+
+.form-group-indent {
+  @include box-sizing(border-box);
+  border-left: 5px solid $grey-3;
+  padding-left: $gutter-half;
+  margin: ($gutter $gutter-two-thirds $gutter 0);
+}
+
+// Inline form layout (tablet and up)
+.form-group-inline {
+  padding-top: $gutter-half;
+}
+.form-group-inline .form-checkbox,
+.form-group-inline .form-radio {
+  float: left;
+  margin-right: $gutter-half;
+  margin-bottom: $gutter-half;
+}
+
+// Block form layout (tablet and up)
+
+.form-group-block {
+  @extend %contain-floats;
+}
+.form-group-block .form-checkbox,
+.form-group-block .form-radio {
+  margin-bottom: $gutter-half;
+}
+
+// Large hit areas for labels wrapping radio buttons and checkboxes
+.form-group label.block-label {
+  display: inline-block;
+}
+
+.block-label {
+  display: inline-block;
+  padding: (18px $gutter $gutter-half $gutter-half);
+  background: $grey-3;
+}
+
+
+// Only if JavaScript is enabled
+// Remove focus styles from radio and checkboxes
+
+.block-label input:focus {
+  outline: none;
+}
+
+// Instead, add focus styles to labels
+
+.add-focus {
+  outline: 3px solid $yellow;
+}
+

--- a/public/sass/elements/_grid-1-2.scss
+++ b/public/sass/elements/_grid-1-2.scss
@@ -1,0 +1,6 @@
+.grid-1-2 {
+  width: 100%;
+  @include media(tablet) {
+    width: 50%;
+  }
+}

--- a/public/sass/elements/_grid-1-3.scss
+++ b/public/sass/elements/_grid-1-3.scss
@@ -1,0 +1,6 @@
+.grid-1-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 33.333333333%;
+  }
+}

--- a/public/sass/elements/_grid-1-4.scss
+++ b/public/sass/elements/_grid-1-4.scss
@@ -1,0 +1,6 @@
+.grid-1-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 25%;
+  }
+}

--- a/public/sass/elements/_grid-2-3.scss
+++ b/public/sass/elements/_grid-2-3.scss
@@ -1,0 +1,6 @@
+.grid-2-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 66.666666667%;
+  }
+}

--- a/public/sass/elements/_grid-3-4.scss
+++ b/public/sass/elements/_grid-3-4.scss
@@ -1,0 +1,6 @@
+.grid-3-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 75%;
+  }
+}

--- a/public/sass/elements/_grid-unit.scss
+++ b/public/sass/elements/_grid-unit.scss
@@ -1,0 +1,11 @@
+// Grid units take 100% width, unless a .grid-width class is applied
+.grid {
+  float: left;
+  width: 100%;
+}
+
+.grid .inner-block {
+  @include media(tablet) {
+    padding: 0 $gutter-half;
+  }
+}

--- a/public/sass/elements/_grid-wrapper.scss
+++ b/public/sass/elements/_grid-wrapper.scss
@@ -1,0 +1,8 @@
+// Wrap grid layout
+.grid-wrapper {
+  @extend %contain-floats;
+  padding: 0 $gutter-half;
+  @include media(tablet) {
+    padding: 0 $gutter-half;
+  }
+}

--- a/public/sass/elements/_helpers.scss
+++ b/public/sass/elements/_helpers.scss
@@ -1,0 +1,31 @@
+// Add missing mixins and variables here
+
+
+// These can be removed once the govuk_frontend_toolkit node module is updated
+
+$gutter: 30px;
+$gutter-one-quarter: $gutter/4;
+$gutter-one-third: $gutter/3;
+$gutter-half: $gutter/2;
+$gutter-two-thirds: $gutter - $gutter-one-third;
+
+
+// Use an include here, since we can't extend the %contain-floats placeholder
+
+@mixin contain-floats {
+  &:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+  @include ie-lte(7) {
+    zoom: 1;
+  }
+}
+
+
+// Apply this to a the .cf 'contain-floats' or 'clearfix' class
+
+.cf {
+  @include contain-floats;
+}

--- a/public/sass/elements/_lists.scss
+++ b/public/sass/elements/_lists.scss
@@ -1,0 +1,40 @@
+dl,
+menu,
+ol,
+ul {
+  margin: 0;
+}
+
+dd {
+  margin-left: 0;
+}
+
+menu,
+ol,
+ul {
+  margin-top: 5px;
+  margin-bottom: 20px;
+  padding: 0;
+}
+
+ul,
+ol {
+  list-style-type: none;
+}
+
+ul li,
+ol li {
+  margin-bottom: 5px;
+}
+
+// Bulleted lists
+.list-bullet {
+  list-style-type: disc;
+  margin-left: 20px;
+}
+
+// Numbered lists
+.list-number {
+  list-style-type: decimal;
+  margin-left: 20px;
+}

--- a/public/sass/elements/_main-wrapper.scss
+++ b/public/sass/elements/_main-wrapper.scss
@@ -1,0 +1,14 @@
+.main {
+  max-width: 1020px;
+  width: auto;
+  margin: 0 auto 90px;
+  @include contain-floats;
+
+  @include ie-lte(6)  {
+    width: 990px;
+  }
+}
+
+.main-full-width {
+	max-width: 100%;
+}

--- a/public/sass/elements/_typography-base.scss
+++ b/public/sass/elements/_typography-base.scss
@@ -1,0 +1,6 @@
+// Increase default font size to 19px
+
+&{
+@include core-19;
+-webkit-font-smoothing: antialiased;
+}

--- a/public/sass/elements/_typography-data.scss
+++ b/public/sass/elements/_typography-data.scss
@@ -1,0 +1,13 @@
+// Data
+.data-80 {
+  @include bold-80;
+}
+
+.data-48 {
+  @include bold-48;
+  line-height: 0.9;
+}
+
+.data p {
+  @include bold-16;
+}

--- a/public/sass/elements/_typography-general.scss
+++ b/public/sass/elements/_typography-general.scss
@@ -1,0 +1,22 @@
+p, 
+pre {
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+.lede,
+.lead {
+  @include core-24;
+}
+
+.copy-16 {
+  @include core-16;
+}
+
+// Set a max-width for text blocks
+// Less than 75 characters per line of text
+
+.text {
+  max-width: 30em;
+}
+

--- a/public/sass/elements/_typography-headings.scss
+++ b/public/sass/elements/_typography-headings.scss
@@ -1,0 +1,44 @@
+.heading-48 {
+  @include bold-48();
+  margin-top: $gutter-half;
+  margin-bottom: $gutter;
+  @include media(tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter*2;
+  }
+  .heading-27 {
+    display: block;
+    @include core-27();
+    color: $secondary-text-colour;
+  }
+}
+
+.heading-36 {
+  @include bold-36();
+  margin-top: 25px;
+  margin-bottom: 10px;
+  @include media(tablet) {
+    margin-top: 45px;
+    margin-bottom: 20px;
+  }
+}
+
+.heading-24 {
+  @include bold-24();
+  margin-top: 25px;
+  margin-bottom: 10px;
+  @include media(tablet) {
+    margin-top: 45px;
+    margin-bottom: 20px;
+  }
+}
+
+.heading-19 {
+  @include bold-19();
+  margin-top: 10px;
+  margin-bottom: 5px;
+  @include media(tablet) {
+    margin-top: 20px;
+  }
+}
+

--- a/public/stylesheets/elements.css
+++ b/public/stylesheets/elements.css
@@ -1,0 +1,707 @@
+/* includes node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit/stylesheets */
+/* CSS 3 Mixins
+
+  Add them as you need them. This should let us manage vendor prefixes in one place.
+ */
+/* Cross-browser shims
+
+  Ways of normalising properties across browsers.
+ */
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+/* Usage:
+   @include inline-block
+
+   or
+
+   @include inline-block("250px")
+
+   which gives a min-height to the inline-block elements.
+*/
+/* Contain floats usage:
+
+   .this-has-floated-children {
+     @extend %contain-floats;
+   }
+
+*/
+%contain-floats:after {
+  content: "";
+  display: block;
+  clear: both; }
+
+@font-face {
+  font-family: GDS-Logo;
+  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
+
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+@font-face {
+  font-family: GDS-Logo;
+  src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); }
+
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+/* Cross-browser shims
+
+  Ways of normalising properties across browsers.
+ */
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+/* Usage:
+   @include inline-block
+
+   or
+
+   @include inline-block("250px")
+
+   which gives a min-height to the inline-block elements.
+*/
+/* Contain floats usage:
+
+   .this-has-floated-children {
+     @extend %contain-floats;
+   }
+
+*/
+%contain-floats:after {
+  content: "";
+  display: block;
+  clear: both; }
+
+/* Cross-browser shims
+
+  Ways of normalising properties across browsers.
+ */
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+/* Usage:
+   @include inline-block
+
+   or
+
+   @include inline-block("250px")
+
+   which gives a min-height to the inline-block elements.
+*/
+/* Contain floats usage:
+
+   .this-has-floated-children {
+     @extend %contain-floats;
+   }
+
+*/
+%contain-floats:after {
+  content: "";
+  display: block;
+  clear: both; }
+
+/* CSS 3 Mixins
+
+  Add them as you need them. This should let us manage vendor prefixes in one place.
+ */
+@-ms-viewport {
+  width: device-width; }
+
+@-o-viewport {
+  width: device-width; }
+
+/*
+
+Mixin and defaults for making buttons on GOV.UK services.
+
+For guidance, see: https://www.gov.uk/service-manual/design-and-content/resources/buttons.html
+
+Example usage:
+
+.button{
+  @include button;
+}
+.button-secondary{
+  @include button($grey-3);
+}
+.button-warning{
+  @include button($red);
+}
+
+*/
+.cf:after {
+  content: "";
+  display: block;
+  clear: both; }
+
+.main {
+  max-width: 1020px;
+  width: auto;
+  margin: 0 auto 90px; }
+  .main:after {
+    content: "";
+    display: block;
+    clear: both; }
+
+.main-full-width {
+  max-width: 100%; }
+
+.govuk {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 19px;
+  line-height: 1.31579;
+  font-weight: 400;
+  text-transform: none;
+  -webkit-font-smoothing: antialiased; }
+  @media (max-width: 640px) {
+    .govuk {
+      font-size: 16px;
+      line-height: 1.25; } }
+.govuk p, .govuk pre {
+  margin-top: 5px;
+  margin-bottom: 20px; }
+.govuk .lede, .govuk .lead {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.25;
+  font-weight: 400;
+  text-transform: none; }
+  @media (max-width: 640px) {
+    .govuk .lede, .govuk .lead {
+      font-size: 20px;
+      line-height: 1.2; } }
+.govuk .copy-16 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 300;
+  text-transform: none; }
+  @media (max-width: 640px) {
+    .govuk .copy-16 {
+      font-size: 14px;
+      line-height: 1.14286; } }
+.govuk .text {
+  max-width: 30em; }
+.govuk .heading-48 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 48px;
+  line-height: 1.04167;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  margin-top: 15px;
+  margin-bottom: 30px; }
+  @media (max-width: 640px) {
+    .govuk .heading-48 {
+      font-size: 32px;
+      line-height: 1.09375; } }
+  @media (min-width: 641px) {
+    .govuk .heading-48 {
+      margin-top: 30px;
+      margin-bottom: 60px; } }
+  .govuk .heading-48 .heading-27 {
+    display: block;
+    font-family: "nta", Arial, sans-serif;
+    font-size: 27px;
+    line-height: 1.11111;
+    font-weight: 400;
+    text-transform: none;
+    color: #6f777b; }
+    @media (max-width: 640px) {
+      .govuk .heading-48 .heading-27 {
+        font-size: 18px;
+        line-height: 1.11111; } }
+.govuk .heading-36 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 36px;
+  line-height: 1.11111;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  margin-top: 25px;
+  margin-bottom: 10px; }
+  @media (max-width: 640px) {
+    .govuk .heading-36 {
+      font-size: 24px;
+      line-height: 1.04167; } }
+  @media (min-width: 641px) {
+    .govuk .heading-36 {
+      margin-top: 45px;
+      margin-bottom: 20px; } }
+.govuk .heading-24 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.25;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  margin-top: 25px;
+  margin-bottom: 10px; }
+  @media (max-width: 640px) {
+    .govuk .heading-24 {
+      font-size: 20px;
+      line-height: 1.2; } }
+  @media (min-width: 641px) {
+    .govuk .heading-24 {
+      margin-top: 45px;
+      margin-bottom: 20px; } }
+.govuk .heading-19 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 19px;
+  line-height: 1.31579;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  margin-top: 10px;
+  margin-bottom: 5px; }
+  @media (max-width: 640px) {
+    .govuk .heading-19 {
+      font-size: 16px;
+      line-height: 1.25; } }
+  @media (min-width: 641px) {
+    .govuk .heading-19 {
+      margin-top: 20px; } }
+.govuk .data-80 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 80px;
+  line-height: 1;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700; }
+  @media (max-width: 640px) {
+    .govuk .data-80 {
+      font-size: 53px;
+      line-height: 1.03774; } }
+.govuk .data-48 {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 48px;
+  line-height: 1.04167;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  line-height: 0.9; }
+  @media (max-width: 640px) {
+    .govuk .data-48 {
+      font-size: 32px;
+      line-height: 1.09375; } }
+.govuk .data p {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 300;
+  text-transform: none;
+  font-weight: 700; }
+  @media (max-width: 640px) {
+    .govuk .data p {
+      font-size: 14px;
+      line-height: 1.14286; } }
+.govuk .grid-wrapper {
+  padding: 0 15px; }
+  @media (min-width: 641px) {
+    .govuk .grid-wrapper {
+      padding: 0 15px; } }
+.govuk .grid {
+  float: left;
+  width: 100%; }
+@media (min-width: 641px) {
+  .govuk .grid .inner-block {
+    padding: 0 15px; } }
+.govuk .grid-1-2 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .grid-1-2 {
+      width: 50%; } }
+.govuk .grid-1-3 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .grid-1-3 {
+      width: 33.33333%; } }
+.govuk .grid-1-4 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .grid-1-4 {
+      width: 25%; } }
+.govuk .grid-2-3 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .grid-2-3 {
+      width: 66.66667%; } }
+.govuk .grid-3-4 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .grid-3-4 {
+      width: 75%; } }
+.govuk .button {
+  background-color: #006435;
+  position: relative;
+  display: -moz-inline-stack;
+  display: inline-block;
+  padding: 0.35em 0.5em 0.15em 0.5em;
+  border: none;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+  -webkit-appearance: none;
+  -webkit-box-shadow: 0 2px 0 #00180c;
+  -moz-box-shadow: 0 2px 0 #00180c;
+  box-shadow: 0 2px 0 #00180c;
+  font-size: 1em;
+  line-height: 1.25;
+  text-decoration: none;
+  -webkit-font-smoothing: antialiased;
+  cursor: pointer;
+  color: #fff;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top; }
+  .govuk .button:visited {
+    background-color: #006435; }
+  .govuk .button:hover, .govuk .button:focus {
+    background-color: #004b26; }
+  .govuk .button:active {
+    top: 2px;
+    -webkit-box-shadow: 0 0 0 #006435;
+    -moz-box-shadow: 0 0 0 #006435;
+    box-shadow: 0 0 0 #006435; }
+  .govuk .button.disabled, .govuk .button[disabled="disabled"], .govuk .button[disabled] {
+    zoom: 1;
+    filter: alpha(opacity=#{$trans * 100});
+    opacity: 0.5; }
+    .govuk .button.disabled:hover, .govuk .button[disabled="disabled"]:hover, .govuk .button[disabled]:hover {
+      cursor: default;
+      background-color: #006435; }
+    .govuk .button.disabled:active, .govuk .button[disabled="disabled"]:active, .govuk .button[disabled]:active {
+      top: 0;
+      -webkit-box-shadow: 0 2px 0 #00180c;
+      -moz-box-shadow: 0 2px 0 #00180c;
+      box-shadow: 0 2px 0 #00180c; }
+  .govuk .button:hover, .govuk .button:focus, .govuk .button:visited {
+    color: #fff; }
+  .govuk .button:before {
+    content: "";
+    height: 110%;
+    width: 100%;
+    display: block;
+    background: transparent;
+    position: absolute;
+    top: 0;
+    left: 0; }
+  .govuk .button:active:before {
+    top: -10%;
+    height: 120%; }
+  .govuk .button[rel="external"]:after {
+    display: none;
+    content: none;
+    margin-left: 0;
+    margin-right: 0; }
+.govuk .button:focus {
+  outline: 3px solid #ffbf47; }
+.govuk .get-started .button {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.25;
+  font-weight: 400;
+  text-transform: none;
+  font-weight: 700;
+  line-height: 0.66667;
+  background-color: #00823b;
+  padding: 0.6em 1.7em 0.45em 0.67em;
+  background-image: url(https://assets.digital.cabinet-office.gov.uk/static/icon-pointer-063838cde108768e30b077e5303783fc.png);
+  background-position: 100% 50%;
+  background-repeat: no-repeat;
+  margin-bottom: 0; }
+  @media (max-width: 640px) {
+    .govuk .get-started .button {
+      font-size: 20px;
+      line-height: 1.2; } }
+.govuk .get-started .button:hover {
+  background-color: #006435; }
+.govuk .get-started .destination {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.42857;
+  font-weight: 400;
+  text-transform: none;
+  color: #2e3133;
+  display: block;
+  margin-top: 7px;
+  max-width: 182px; }
+  @media (max-width: 640px) {
+    .govuk .get-started .destination {
+      font-size: 12px;
+      line-height: 1.25; } }
+.govuk .button-link {
+  background: none;
+  border: none;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  color: #2e3191;
+  line-height: 1.25;
+  text-decoration: underline;
+  cursor: pointer;
+  margin: 0 15px 15px 0;
+  padding: 10px 10px 5px 10px;
+  vertical-align: top; }
+.govuk .button-link:hover {
+  color: #2e8aca; }
+.govuk .button-link:focus {
+  outline: 3px solid #ffbf47; }
+.govuk .colour-purple {
+  background-color: #2e358b; }
+.govuk .colour-purple-50 {
+  background-color: #9799c4; }
+.govuk .colour-purple-25 {
+  background-color: #d5d6e7; }
+.govuk .colour-mauve {
+  background-color: #6f72af; }
+.govuk .colour-mauve-50 {
+  background-color: #b7b9d7; }
+.govuk .colour-mauve-25 {
+  background-color: #e2e2ef; }
+.govuk .colour-fuschia {
+  background-color: #912b88; }
+.govuk .colour-fuschia-50 {
+  background-color: #c994c3; }
+.govuk .colour-fuschia-25 {
+  background-color: #e9d4e6; }
+.govuk .colour-pink {
+  background-color: #d53880; }
+.govuk .colour-pink-50 {
+  background-color: #eb9bbe; }
+.govuk .colour-pink-25 {
+  background-color: #f6d7e5; }
+.govuk .colour-baby-pink {
+  background-color: #f499be; }
+.govuk .colour-baby-pink-50 {
+  background-color: #faccdf; }
+.govuk .colour-baby-pink-25 {
+  background-color: #fdebf2; }
+.govuk .colour-red {
+  background-color: #b10e1e; }
+.govuk .colour-red-50 {
+  background-color: #d9888c; }
+.govuk .colour-red-25 {
+  background-color: #efcfd1; }
+.govuk .colour-mellow-red {
+  background-color: #df3034; }
+.govuk .colour-mellow-red-50 {
+  background-color: #ef9998; }
+.govuk .colour-mellow-red-25 {
+  background-color: #f9d6d6; }
+.govuk .colour-orange {
+  background-color: #f47738; }
+.govuk .colour-orange-50 {
+  background-color: #fabb96; }
+.govuk .colour-orange-25 {
+  background-color: #fde4d4; }
+.govuk .colour-brown {
+  background-color: #b58840; }
+.govuk .colour-brown-50 {
+  background-color: #dac39c; }
+.govuk .colour-brown-25 {
+  background-color: #f0e7d7; }
+.govuk .colour-yellow {
+  background-color: #ffbf47; }
+.govuk .colour-yellow-50 {
+  background-color: #ffdf94; }
+.govuk .colour-yellow-25 {
+  background-color: #fff2d3; }
+.govuk .colour-green {
+  background-color: #006435; }
+.govuk .colour-green-50 {
+  background-color: #7fb299; }
+.govuk .colour-green-25 {
+  background-color: #cce0d6; }
+.govuk .colour-grass-green {
+  background-color: #85994b; }
+.govuk .colour-grass-green-50 {
+  background-color: #c2cca3; }
+.govuk .colour-grass-green-25 {
+  background-color: #e7ebda; }
+.govuk .colour-turquoise {
+  background-color: #28a197; }
+.govuk .colour-turquoise-50 {
+  background-color: #95d0cb; }
+.govuk .colour-turquoise-25 {
+  background-color: #d5ecea; }
+.govuk .colour-light-blue {
+  background-color: #2b8cc4; }
+.govuk .colour-light-blue-50 {
+  background-color: #96c6e2; }
+.govuk .colour-light-blue-25 {
+  background-color: #d5e8f3; }
+.govuk .text-secondary {
+  color: #6f777b; }
+.govuk .bg-hm-government {
+  background: #0076c0; }
+.govuk dl, .govuk menu, .govuk ol, .govuk ul {
+  margin: 0; }
+.govuk dd {
+  margin-left: 0; }
+.govuk menu, .govuk ol, .govuk ul {
+  margin-top: 5px;
+  margin-bottom: 20px;
+  padding: 0; }
+.govuk ul, .govuk ol {
+  list-style-type: none; }
+.govuk ul li, .govuk ol li {
+  margin-bottom: 5px; }
+.govuk .list-bullet {
+  list-style-type: disc;
+  margin-left: 20px; }
+.govuk .list-number {
+  list-style-type: decimal;
+  margin-left: 20px; }
+.govuk form {
+  margin: 0; }
+.govuk fieldset {
+  width: 100%;
+  float: left;
+  clear: both;
+  margin-left: 0; }
+.govuk legend {
+  padding-left: 0;
+  width: 100%;
+  float: left;
+  clear: both; }
+.govuk legend.heading-36 {
+  margin: 0;
+  padding-top: 45px;
+  padding-bottom: 45px; }
+.govuk legend.heading-24 {
+  margin: 0;
+  padding-top: 45px;
+  padding-bottom: 20px; }
+.govuk button, .govuk input, .govuk select, .govuk textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle; }
+.govuk button, .govuk input {
+  line-height: normal; }
+.govuk input[type="text"], .govuk input[type="email"], .govuk input[type="date"], .govuk input[type="datetime"], .govuk input[type="datetime-local"], .govuk input[type="email"], .govuk input[type="month"], .govuk input[type="number"], .govuk input[type="search"], .govuk input[type="tel"], .govuk input[type="time"], .govuk input[type="url"], .govuk input[type="week"], .govuk select[size], .govuk textarea {
+  font-size: 1em;
+  padding: 4px;
+  background-color: #fff;
+  border: 1px solid #bfc1c3;
+  -webkit-appearance: none;
+  border-radius: 0; }
+.govuk textarea {
+  overflow: auto;
+  vertical-align: top;
+  min-height: 190px;
+  height: auto; }
+.govuk .form-group {
+  float: left;
+  width: 100%;
+  clear: both; }
+  @media (min-width: 641px) {
+    .govuk .form-group {
+      margin-bottom: 45px; } }
+.govuk .form-group-compound {
+  margin-bottom: 10px; }
+.govuk .form-label, .govuk .govuk .date-of-birth legend, .govuk .date-of-birth .govuk legend, .govuk .form-group label {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 19px;
+  line-height: 1.31579;
+  font-weight: 400;
+  text-transform: none;
+  display: block;
+  margin-bottom: 5px; }
+  @media (max-width: 640px) {
+    .govuk .form-label, .govuk .form-group label {
+      font-size: 16px;
+      line-height: 1.25; } }
+.govuk .form-control {
+  width: 100%;
+  box-sizing: border-box; }
+  @media (min-width: 641px) {
+    .govuk .form-control {
+      width: 50%; } }
+.govuk .form-control-3-4 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .form-control-3-4 {
+      width: 75%; } }
+.govuk .form-control-1-2 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .form-control-1-2 {
+      width: 50%; } }
+.govuk .form-control-1-4 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .form-control-1-4 {
+      width: 25%; } }
+.govuk .form-control-1-8 {
+  width: 100%; }
+  @media (min-width: 641px) {
+    .govuk .form-control-1-8 {
+      width: 12.5%; } }
+.govuk .form-hint {
+  display: block;
+  color: #6f777b;
+  margin-top: 8px;
+  margin-bottom: 5px; }
+.govuk .date-of-birth label {
+  display: block;
+  color: #6f777b;
+  margin-bottom: 5px; }
+@media (min-width: 641px) {
+  .govuk .date-of-birth .form-group {
+    width: 50px;
+    float: left;
+    margin-right: 20px;
+    clear: none; } }
+@media (min-width: 641px) {
+  .govuk .date-of-birth .form-group-year {
+    width: 70px; } }
+.govuk .date-of-birth .form-group input {
+  width: 100%; }
+.govuk .form-checkbox input {
+  vertical-align: middle;
+  margin: -2px 5px 0 0; }
+.govuk .form-radio input {
+  vertical-align: middle;
+  margin: -4px 5px 0 0; }
+.govuk .form-group-indent {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  border-left: 5px solid #dee0e2;
+  padding-left: 15px;
+  margin: 30px 20px 30px 0; }
+.govuk .form-group-inline {
+  padding-top: 15px; }
+.govuk .form-group-inline .form-checkbox, .govuk .form-group-inline .form-radio {
+  float: left;
+  margin-right: 15px;
+  margin-bottom: 15px; }
+.govuk .form-group-block .form-checkbox, .govuk .form-group-block .form-radio {
+  margin-bottom: 15px; }
+.govuk .form-group label.block-label {
+  display: inline-block; }
+.govuk .block-label {
+  display: inline-block;
+  padding: 18px 30px 15px 15px;
+  background: #dee0e2; }
+.govuk .block-label input:focus {
+  outline: none; }
+.govuk .add-focus {
+  outline: 3px solid #ffbf47; }

--- a/routes.js
+++ b/routes.js
@@ -33,5 +33,20 @@ module.exports = {
                 {'assetPath' : assetPath});
       
     });
+
+    /* Elements example pages */
+
+    app.get('/examples/elements/grid-layout', function (req, res) {
+      res.render('examples/elements/grid_layout', {'assetPath' : assetPath });    
+    });
+
+    app.get('/examples/elements/typography', function (req, res) {
+      res.render('examples/elements/typography', {'assetPath' : assetPath });    
+    });
+    
+    app.get('/examples/elements/forms', function (req, res) {
+      res.render('examples/elements/forms', {'assetPath' : assetPath });    
+    });
+
   }
 };

--- a/views/examples/elements/forms.html
+++ b/views/examples/elements/forms.html
@@ -1,0 +1,290 @@
+{{<govuk_template}}
+
+{{$head}}
+  {{>elements_head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main class="main govuk">
+
+  <div class="grid-wrapper">
+    <div class="grid">
+      <div class="inner-block">
+
+        <p class="heading-19">
+          Elements example pages
+        </p>
+        <ul class="list-bullet">
+          <li><a href="/examples/elements/grid-layout">Grid layout</a></li>
+          <li><a href="/examples/elements/typography">Typography</a></li>
+          <li><a href="/examples/elements/forms">Forms</a></li>
+        </ul>
+
+        <h1 class="heading-48">
+          Forms
+        </h1>
+
+        <form action="get" class="form">
+          
+          <!-- Fieldset with hint and example text -->
+
+          <fieldset>
+            
+            <legend class="heading-36">
+              Your personal details
+            </legend>
+
+            <div class="form-group">
+              <label class="form-label" for="full-name">Full name</label>
+              <p class="form-hint">As shown on your birth certificate or passport</p>
+              <input type="text" class="form-control" id="full-name">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="other-names">Any other last names</label>
+              <input type="text" class="form-control" id="other-names">
+              <p class="form-hint">E.g. your maiden name</p>
+            </div>
+
+          </fieldset>
+
+          <!-- Date of birth -->
+
+          <fieldset class="date-of-birth">
+
+            <legend>
+              Date of birth
+            </legend>
+            <div class="form-group">
+              <label for="dob-day">Day</label>
+              <input type="text" class="form-control" pattern="[0-9]*" id="dob-day">
+            </div>
+            <div class="form-group">
+              <label for="dob-month">Month</label>
+              <input type="text" class="form-control" id="dob-month">
+            </div>
+            <div class="form-group form-group-year">
+              <label for="dob-year">Year</label>
+              <input type="text" class="form-control" pattern="[0-9]*" id="dob-year">
+            </div>
+
+          </fieldset>
+          
+          <!-- Compound form controls -->
+
+          <fieldset>
+
+            <legend class="heading-36">
+              Your address
+            </legend>
+
+             <div class="form-group form-group-compound">
+              <label class="form-label" for="address-line-1">Street address</label>
+              <input type="text" class="form-control" id="address-line-1">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="address-line-2" class="visuallyhidden">Second line of address</label>
+              <input type="text" class="form-control" id="address-line-2">
+            </div>
+            
+            <div class="form-group">
+              <label class="form-label" for="address-town">Town or City</label>
+              <input type="text" class="form-control form-control-1-4" id="address-town">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="address-postcode">Postcode</label>
+              <input type="text" class="form-control form-control-1-8" id="address-postcode">
+            </div>
+
+          </fieldset>
+
+          <!-- Primary and secondary buttons -->
+
+          <fieldset>
+            
+            <div class="form-group">
+              <input type="submit" class="button" value="Next">
+              <button class="button-link">Back</button>
+            </div>
+
+          </fieldset>
+          
+          <!-- Block form layout (radio buttons & checkboxes) -->
+
+          <fieldset>
+            
+            <legend class="heading-24">
+              Block layout
+            </legend>
+
+            <!-- Radio buttons -->
+
+            <div class="form-group form-group-block">
+
+              <div class="form-radio">
+                <label for="radio-option-1a" class="block-label">
+                  <input id="radio-option-1a" type="radio" name="option-radio" value="">
+                  Radio option 1
+                </label>
+              </div>
+              <div class="form-radio">
+                <label for="radio-option-2a" class="block-label">
+                  <input id="radio-option-2a" type="radio" name="option-radio" value="">
+                  Radio option 2
+                </label>
+              </div>
+
+            </div>
+
+            <!-- Checkboxes -->
+
+            <div class="form-group form-group-block">
+
+              <div class="form-checkbox">
+                <label for="checkbox-option-1b" class="block-label">
+                  <input id="checkbox-option-1b" type="checkbox" value="">
+                  Checkbox option 1
+                </label>
+              </div>
+              <div class="form-checkbox">
+                <label for="checkbox-option-2b" class="block-label">
+                  <input id="checkbox-option-2b" type="checkbox" value="">
+                  Checkbox option 2
+                </label>
+              </div>
+            
+            </div>
+
+          </fieldset>
+        
+          <!-- Inline form layout (radio buttons & checkboxes) -->
+          
+          <fieldset>
+            
+            <legend class="heading-24">
+              Inline layout
+            </legend>
+
+            <!-- Radio buttons -->
+
+            <div class="form-group form-group-inline">
+
+              <div class="form-radio">
+                <label for="radio-option-3a" class="block-label">
+                  <input id="radio-option-3a" type="radio" name="option-radio" value="">
+                  Yes
+                </label>
+              </div>
+              <div class="form-radio">
+                <label for="radio-option-4b" class="block-label">
+                  <input id="radio-option-4b" type="radio" name="option-radio" value="">
+                  No
+                </label>
+              </div>
+
+            </div>
+            
+            <!-- Checkboxes -->
+
+            <div class="form-group form-group-inline">
+
+              <div class="form-checkbox">
+                <label for="checkbox-option-3a" class="block-label">
+                  <input id="checkbox-option-3a" type="checkbox" value="">
+                  Checkbox option 1
+                </label>
+              </div>
+              <div class="form-checkbox">
+                <label for="checkbox-option-4b" class="block-label">
+                  <input id="checkbox-option-4b" type="checkbox" value="">
+                  Checkbox option 2
+                </label>
+              </div>
+
+            </div>
+
+          </fieldset>
+
+          <!-- Block form layout (radio buttons & checkboxes) -->
+
+          <fieldset>
+            
+            <legend class="heading-24">
+              Radio buttons and checkboxes
+            </legend>
+
+            <!-- Radio buttons -->
+
+            <div class="form-group form-group-block">
+
+              <div class="form-radio">
+                <label for="radio-option-1c">
+                  <input id="radio-option-1c" type="radio" name="option-radio" value="">
+                  Radio option 1
+                </label>
+              </div>
+              <div class="form-radio">
+                <label for="radio-option-2c">
+                  <input id="radio-option-2c" type="radio" name="option-radio" value="">
+                  Radio option 2
+                </label>
+              </div>
+
+            </div>
+
+            <!-- Checkboxes -->
+
+            <div class="form-group form-group-block">
+
+              <div class="form-checkbox">
+                <label for="checkbox-option-1d">
+                  <input id="checkbox-option-1d" type="checkbox" value="">
+                  Checkbox option 1
+                </label>
+              </div>
+              <div class="form-checkbox">
+                <label for="checkbox-option-2d">
+                  <input id="checkbox-option-2d" type="checkbox" value="">
+                  Checkbox option 2
+                </label>
+              </div>
+            
+            </div>
+
+          </fieldset>
+          
+          <!-- Indented form content -->
+
+          <fieldset>
+            
+            <legend class="heading-24">
+              Indented form content
+            </legend>
+
+            <div class="form-group form-group-indent">
+              <div class="text">
+                <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent commodo cursus magna.</p>
+
+                <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+              </div>
+            </div>
+          </fieldset>
+
+        </form>
+        
+      </div><!-- /.inner-block -->
+    </div><!-- /.grid -->
+  </div><!-- /.grid-wrapper -->
+
+</main>
+{{/content}}
+
+{{/govuk_template}}

--- a/views/examples/elements/grid_layout.html
+++ b/views/examples/elements/grid_layout.html
@@ -1,0 +1,145 @@
+{{<govuk_template}}
+
+{{$head}}
+  {{>elements_head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main class="main govuk">
+  <div class="grid-wrapper">
+    <div class="grid">
+      <div class="inner-block">
+
+        <p class="heading-19">
+          Elements example pages
+        </p>
+        <ul class="list-bullet">
+          <li><a href="/examples/elements/grid-layout">Grid layout</a></li>
+          <li><a href="/examples/elements/typography">Typography</a></li>
+          <li><a href="/examples/elements/forms">Forms</a></li>
+        </ul>
+
+        <h1 class="heading-48">
+          Grid layout
+        </h1>
+
+        <h2 class="heading-36">Full width</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+        
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-wrapper">
+    <div class="grid grid-2-3">
+      <div class="inner-block">
+        
+        <h2 class="heading-36">Two thirds</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+        
+      </div>
+    </div>
+    <div class="grid grid-1-3">
+      <div class="inner-block">
+        <h2 class="heading-36">One third</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-wrapper">
+    <div class="grid grid-1-2">
+      <div class="inner-block">
+        <h2 class="heading-36">One half</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-2">
+      <div class="inner-block">
+        <h2 class="heading-36">One half</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+  </div>
+  
+  <div class="grid-wrapper">
+    <div class="grid grid-1-3">
+      <div class="inner-block">
+        <h2 class="heading-36">One third</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-3">
+      <div class="inner-block">
+        <h2 class="heading-36">One third</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-3">
+      <div class="inner-block">
+        <h2 class="heading-36">One third</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-wrapper">
+    <div class="grid grid-1-4">
+      <div class="inner-block">
+        <h2 class="heading-36">One quarter</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-4">
+      <div class="inner-block">
+        <h2 class="heading-36">One quarter</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-4">
+      <div class="inner-block">
+        <h2 class="heading-36">One quarter</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+    <div class="grid grid-1-4">
+      <div class="inner-block">
+        <h2 class="heading-36">One quarter</h2>
+        <p>Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ullamcorper nulla non metus auctor fringilla. Aenean lacinia bibendum nulla sed consectetur. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam quis risus eget urna mollis ornare vel eu leo. Aenean lacinia bibendum nulla sed consectetur.</p>
+      </div>
+    </div>
+  </div>
+</main>
+{{/content}}
+
+{{/govuk_template}}

--- a/views/examples/elements/typography.html
+++ b/views/examples/elements/typography.html
@@ -1,0 +1,83 @@
+{{<govuk_template}}
+
+{{$head}}
+  {{>elements_head}}
+{{/head}}
+
+{{$propositionHeader}}
+  {{>propositional_navigation}}
+{{/propositionHeader}}
+
+{{$headerClass}}with-proposition{{/headerClass}}
+
+{{$content}}
+<main class="main govuk">
+
+  <div class="grid-wrapper">
+    <div class="grid">
+      <div class="inner-block">
+        
+        <p class="heading-19">
+          Elements example pages
+        </p>
+        <ul class="list-bullet">
+          <li><a href="/examples/elements/grid-layout">Grid layout</a></li>
+          <li><a href="/examples/elements/typography">Typography</a></li>
+          <li><a href="/examples/elements/forms">Forms</a></li>
+        </ul>
+
+        <h1 class="heading-48">
+          Typography
+        </h1>
+
+        <div class="text">
+          
+          <h1 class="heading-48">
+            <span class="heading-27">A 27px section heading</span>
+            A 48px heading
+          </h1>
+          
+          <p class="lede">
+            This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+          </p>
+
+          <h2 class="heading-36">A 36px heading</h2>
+
+          <p>
+            Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
+          </p>
+
+          <h3 class="heading-24">A 24px heading</h3>
+
+          <p>
+          Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
+          </p>
+
+          <h4 class="heading-19">A 19px heading</h4>
+
+          <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+
+          <ul class="list-bullet">
+            <li>Here is a bulleted list.</li>
+            <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+            <li>Vestibulum id ligula porta felis euismod semper.</li>
+            <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
+          </ul>
+
+          <ol class="list-number">
+            <li>Here is a numbered list.</li>
+            <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+            <li>Vestibulum id ligula porta felis euismod semper.</li>
+            <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
+          </ol>
+          
+        </div>
+
+      </div><!-- /.inner-block -->
+    </div><!-- /.grid -->
+  </div><!-- /.grid-wrapper -->
+
+</main>
+{{/content}}
+
+{{/govuk_template}}

--- a/views/includes/elements_head.html
+++ b/views/includes/elements_head.html
@@ -1,0 +1,2 @@
+<link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
+<link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Propose adding example styles to prototype
- Add new Elements route and templates
- Add Elements base styles
- Show typography, grid and form example pages

Please note: This is very much a first pass, to find out if this
structure and format is acceptable to @tombye within the existing
prototype.
