### PR TITLE
Pass command line arguments to server.js, and use --verbose to show 'stored template'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,8 @@ module.exports = function(grunt){
         script: 'server.js',
         options: {
           ext: 'html, js',
-          ignore: ['node_modules/**']
+          ignore: ['node_modules/**'],
+          args: grunt.option.flags()
         }
       }
     },

--- a/lib/template-engine.js
+++ b/lib/template-engine.js
@@ -5,6 +5,7 @@ var Hogan = require('hogan.js');
 var ReadDir = require('readdir');
 var Path = require('path');
 var FS = require('fs');
+var argv = require('minimist')(process.argv.slice(2));
 
 function TemplateEngine() {
 }
@@ -93,7 +94,9 @@ TemplateEngine._storeTemplate = function (basePath) {
 
       TemplateEngine.__templates[templateName] = Hogan.compile(FS.readFileSync(templatePath, 'utf-8'));
 
-      console.log('Stored template', templateName);
+      if (argv.verbose){
+         console.log('Stored template', templateName);
+      }
    };
 };
 

--- a/start.js
+++ b/start.js
@@ -9,7 +9,9 @@ gruntfile = (argv.ruby) ? __dirname + '/Gruntfile_ruby_sass.js' : __dirname + '/
 require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
   'gruntfile' : gruntfile
 });
+
 fs.writeFileSync(pidFile, process.pid, fileOptions);
+
 process.on('SIGINT', function() {
   var pid = fs.readFileSync(pidFile, fileOptions);
 


### PR DESCRIPTION
It's useful to pass arguments to the app. For example we could set a port number

It's useful to hide 'stored template' unless needed as it obscures your own console.log() output
