### PR TITLE
Split Grunt task to run differently on Heroku

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt){
             'govuk_modules/govuk_frontend_toolkit/stylesheets'
           ],
           outputStyle: 'expanded'
-        } 
+        }
       }
     },
 
@@ -43,7 +43,7 @@ module.exports = function(grunt){
       fixSass: {
         src: ['govuk_modules/govuk_template/**/*.scss', 'govuk_modules/govuk_frontend_toolkit/**/*.scss'],
         overwrite: true,
-        replacements: [{ 
+        replacements: [{
           from: /filter:chroma(.*);/g,
           to: 'filter:unquote("chroma$1");'
         }]
@@ -91,7 +91,7 @@ module.exports = function(grunt){
   ].forEach(function (task) {
     grunt.loadNpmTasks(task);
   });
-  
+
   grunt.registerTask(
     'convert_template',
     'Converts the govuk_template to use mustache inheritance',
@@ -103,13 +103,17 @@ module.exports = function(grunt){
     }
   );
 
-  grunt.registerTask('default', [
+  grunt.registerTask('generate-assets', [
     'copy:govuk_template',
     'copy:govuk_frontend_toolkit',
     'convert_template',
     'copy:govuk_frontend_toolkit',
     'replace',
-    'sass',
+    'sass'
+  ]);
+
+  grunt.registerTask('default', [
+    'generate-assets',
     'concurrent:target'
   ]);
 };

--- a/Gruntfile_ruby_sass.js
+++ b/Gruntfile_ruby_sass.js
@@ -15,7 +15,7 @@ module.exports = function(grunt){
             'govuk_modules/govuk_frontend_toolkit/stylesheets'
           ],
           style: 'expanded'
-        } 
+        }
       }
     },
 
@@ -77,7 +77,7 @@ module.exports = function(grunt){
   ].forEach(function (task) {
     grunt.loadNpmTasks(task);
   });
-  
+
   grunt.registerTask(
     'convert_template',
     'Converts the govuk_template to use mustache inheritance',
@@ -89,12 +89,18 @@ module.exports = function(grunt){
     }
   );
 
-  grunt.registerTask('default', [
+  grunt.registerTask('generate-assets', [
     'copy:govuk_template',
     'copy:govuk_frontend_toolkit',
     'convert_template',
     'copy:govuk_frontend_toolkit',
-    'sass',
+    'replace',
+    'sass'
+  ]);
+
+  grunt.registerTask('default', [
+    'generate-assets',
     'concurrent:target'
   ]);
+
 };

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node start.js
+web: grunt --gruntfile Gruntfile.js generate-assets && node server.js


### PR DESCRIPTION
Previously running Grunt on Heroku left `watch` and `nodemon` running unnecessarily.

Now we call Grunt in the Procfile with an argument that makes sure it doesn't run `watch` or `nodemon`.

CAVEAT: If you're using Ruby SASS, you will have to change the Procfile to specify Gruntfile_ruby_sass.js