### PR TITLE
Remove application.css from elements header include

### DIFF
--- a/app/views/examples/elements/forms.html
+++ b/app/views/examples/elements/forms.html
@@ -1,7 +1,7 @@
 {{<govuk_template}}
 
 {{$head}}
-  {{>includes/head}}
+  {{>includes/elements_head}}
 {{/head}}
 
 {{$propositionHeader}}

--- a/app/views/includes/elements_head.html
+++ b/app/views/includes/elements_head.html
@@ -1,2 +1,1 @@
-<link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
The `elements_head.html` include is only used for the elements example pages,
seen at:
examples/elements/forms
examples/elements/typography
examples/elements/grid-layout

There’s no need for the application.css file to be linked to here.

Also add missing elements_head include to the forms example page,
so all elements examples use the same include.