### PR TITLE
Set layout template to use header include

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,8 +1,7 @@
 {{<govuk_template}}
 
 {{$head}}
-	<link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
-	<link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" />
+  {{>includes/head}}
 {{/head}}
 
 {{$propositionHeader}}


### PR DESCRIPTION
Here we only want to link to application.css, which imports the
elements styles. There’s no need to link to both stylesheets.
