### PR TITLE
Finish removal of support for Ruby Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,3 @@ Guides for getting set up and how to work with the prototyping application are a
 
 This project is built on top of Express, the idea is that it is straightforward to create simple static pages out of the box. However, you're not limited to that - more dynamic sites can be built with more understanding of Express. Here's a good [Express tutorial.](http://code.tutsplus.com/tutorials/introduction-to-express--net-33367)
 
-## Sass Disclaimer
-
-This app uses the [lib-sass](https://github.com/hcatlin/libsass) implementation of Sass to compile its CSS. It's still a work in progress so is missing a few features.
-
-The one that may effect you is the lack of support for [@extend-only selectors](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#placeholders). This means the you can't use [@extend %contain-floats](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_shims.scss#L45) from the toolkit.
-
-This is explained in more detail [on the wiki](https://github.com/tombye/express_prototype/wiki/Writing-CSS#wiki-we-use-node-sass).
-
-If you need to use the Ruby version of Sass, Run the app like so:
-
-```
-node start.js --ruby
-```

--- a/start.js
+++ b/start.js
@@ -5,7 +5,7 @@ var fs = require('fs'),
     gruntfile;
 
 // start grunt
-gruntfile = (argv.ruby) ? __dirname + '/Gruntfile_ruby_sass.js' : __dirname + '/Gruntfile.js';
+gruntfile = __dirname + '/Gruntfile.js';
 require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
   'gruntfile' : gruntfile
 });


### PR DESCRIPTION
There was still an option to call `start.js` with a flag to let you use Ruby Sass. This was missed in https://github.com/tombye/express_prototype/pull/44 so this removes it and the explanation for it in the docs.