### PR TITLE
Autoroute error handling

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1,5 +1,5 @@
 module.exports = {
-  bind : function (app, assetPath) {
+  bind : function (app) {
 
     app.get('/', function (req, res) {
       res.render('index');

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,23 +1,11 @@
 module.exports = {
   bind : function (app, assetPath) {
+
     app.get('/', function (req, res) {
-      res.render('index',
-                {'assetPath' : assetPath});
+      res.render('index');
     });
 
-    /* Example pages */
-
-    app.get('/examples/hello-world', function (req, res) {
-      res.render('examples/hello-world', {'message' : 'Hello world'});
-    });
-
-    app.get('/examples/inheritance', function (req, res) {
-      res.render('examples/inheritance/page-level', {'message' : 'Hello world'});
-    });
-
-    app.get('/examples/alpha', function (req, res) {
-      res.render('examples/alpha/alpha', {'assetPath' : assetPath });    
-    });
+    // add your routes here
 
   }
 };

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
-var express = require('express'),
+var path = require('path'),
+    express = require('express'),
     routes = require(__dirname + '/app/routes.js'),
     app = express(),
     port = (process.env.PORT || 3000),
@@ -29,6 +30,8 @@ app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit'));
 
+app.use(express.favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico'))); 
+
 
 // send assetPath to all views
 app.use(function (req, res, next) {
@@ -43,7 +46,7 @@ routes.bind(app);
 
 // auto render any view that exists
 
-app.get(/^\/(.+)/, function (req, res) {
+app.get(/^\/([^.]+)$/, function (req, res) {
 
 	var path = (req.params[0]);
 

--- a/server.js
+++ b/server.js
@@ -29,11 +29,17 @@ app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit'));
 
-// routes (found in routes.js)
 
-var assetPath = '/public/';
+// send assetPath to all views
+app.use(function (req, res, next) {
+  res.locals({'assetPath': '/public/'});
+  next();
+});
 
-routes.bind(app, assetPath);
+
+// routes (found in app/routes.js)
+
+routes.bind(app);
 
 // auto render any view that exists
 

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ app.get(/^\/(.+)/, function (req, res) {
 
 	var path = (req.params[0]);
 
-	res.render(path, {'assetPath' : assetPath }, function(err, html) {
+	res.render(path, function(err, html) {
 		if (err) {
 			console.log(err);
 			res.send(404);


### PR DESCRIPTION
 - autoroute no longer tries to handle assets (it doesnt match any path with a . in it)
 - favicon is always served (and therefore doesnt error), regardless of whether the route exists.