### PR TITLE
Remove full stops

### DIFF
--- a/docs/principles.md
+++ b/docs/principles.md
@@ -7,6 +7,6 @@ The prototyping kit:
 - requires minimal skills to get started: HTML, CSS
 - makes use of existing GOV.UK tools and templates; the [GOV.UK template](https://github.com/alphagov/govuk_template), [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit) and [GOV.UK elements](https://github.com/alphagov/govuk_elements)
 - allows for server-side code
-- can be extended - for example using NPM to install a module, access datastores, etc.
+- can be extended - for example using NPM to install a module, access datastores, etc
 - makes it easy to share prototypes with others online
-- should be fully documented in a way that is accessible to the target audience.
+- should be fully documented in a way that is accessible to the target audience


### PR DESCRIPTION
Keeping to the content style guide:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style

etc
Don’t use full stops after or between these notations.

bulleted lists
there is no full stop after the last bullet point