### PR TITLE
Add '/icons' path

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ app.set('views', __dirname + '/app/views');
 app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit'));
+app.use('/icons', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit/images'));
 
 app.use(express.favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico'))); 
 


### PR DESCRIPTION
Add '/icons' path so that the Elements _icons.scss image references point to the right place. This makes the arrow appear on the Start now button for example.